### PR TITLE
Fix broken link to spec draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # postcss-custom-media [![Build Status](https://travis-ci.org/postcss/postcss-custom-media.png)](https://travis-ci.org/postcss/postcss-custom-media)
 
-> [PostCSS](https://github.com/postcss/postcss) plugin to transform [W3C CSS Custom Media Queries](http://dev.w3.org/csswg/mediaqueries/#custom-mq) syntax to more compatible CSS.
+> [PostCSS](https://github.com/postcss/postcss) plugin to transform [W3C CSS Custom Media Queries](https://www.w3.org/TR/2016/WD-mediaqueries-4-20160126/#custom-mq) syntax to more compatible CSS.
 
 ## Installation
 


### PR DESCRIPTION
The existing link does not seem to work anymore, so I substituted a Working Draft link that does.