### PR TITLE
docs: explain better usage of extensions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Checkout [tests](test) for more examples.
 Allows you to pass an object to define the `<media-query-list>` for each
 `<extension-name>`. These definitions will override any that exist in the CSS.
 
+```javascript
+{
+  '--phone': '(min-width: 544px)',
+  '--tablet': '(min-width: 768px)',
+  '--desktop': '(min-width: 992px)',
+  '--large-desktop': '(min-width: 1200px)',
+}
+```
+
 #### `preserve`
 
 (default: `false`)


### PR DESCRIPTION
Fixes #20. 
@MoOx  Note also that yout suggestion in the related issue is wrong, at least for me, because `max-width: 30em` without parentheses does not work and `@media max-width: 30em` appears literally in generated CSS.