### PR TITLE
Add fix for whitespace in media rules

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -235,5 +235,8 @@ module.exports = {
 				throw new Error('The original file did not match the freshly exported copy');
 			}
 		}
-	}
+	},
+	'whitespace': {
+		message: 'supports whitespace'
+	},
 };

--- a/lib/transform-atrules.js
+++ b/lib/transform-atrules.js
@@ -26,4 +26,4 @@ export default (atrule, { preserve }, { customMedia }) => {
 };
 
 const visitedFlag = Symbol("customMediaVisited");
-const customPseudoRegExp = /\(--[A-z][\w-]*\)/;
+const customPseudoRegExp = /\(\s*--[A-z][\w-]*\s*\)/;

--- a/lib/transform-media-list.js
+++ b/lib/transform-media-list.js
@@ -78,7 +78,7 @@ function transformMedia(media, customMedias) {
 	return transpiledMedias;
 }
 
-const customPseudoRegExp = /\((--[A-z][\w-]*)\)/;
+const customPseudoRegExp = /\(\s*(--[A-z][\w-]*)\s*\)/;
 
 const getCustomMediasWithoutKey = (customMedias, key) => {
 	const nextCustomMedias = Object.assign({}, customMedias);

--- a/test/whitespace.css
+++ b/test/whitespace.css
@@ -1,0 +1,109 @@
+@custom-media --mq-a (max-width: 30em), (max-height: 30em);
+
+@media ( --mq-a) {
+	body {
+		order: 1;
+	}
+}
+
+@media (--mq-a ) {
+	body {
+		order: 1;
+	}
+}
+
+@media ( --mq-a ) {
+	body {
+		order: 1;
+	}
+}
+
+@media (   --mq-a   ) {
+	body {
+		order: 1;
+	}
+}
+
+@media ( --mq-a), (--mq-a) {
+	body {
+		order: 2;
+	}
+}
+
+@media (--mq-a), ( --mq-a) {
+	body {
+		order: 2;
+	}
+}
+
+@media ( --mq-a), ( --mq-a) {
+	body {
+		order: 2;
+	}
+}
+
+@media (--mq-a ), (--mq-a) {
+	body {
+		order: 2;
+	}
+}
+
+@media (--mq-a), (--mq-a ) {
+	body {
+		order: 2;
+	}
+}
+
+@media (--mq-a ), (--mq-a ) {
+	body {
+		order: 2;
+	}
+}
+
+@media ( --mq-a), (--mq-a ) {
+	body {
+		order: 2;
+	}
+}
+
+@media (--mq-a ), ( --mq-a) {
+	body {
+		order: 2;
+	}
+}
+
+@media ( --mq-a ), ( --mq-a ) {
+	body {
+		order: 2;
+	}
+}
+
+@media (   --mq-a   ), (   --mq-a   ) {
+	body {
+		order: 2;
+	}
+}
+
+@media not all and ( --mq-a) {
+	body {
+		order: 3;
+	}
+}
+
+@media not all and (--mq-a ) {
+	body {
+		order: 3;
+	}
+}
+
+@media not all and ( --mq-a ) {
+	body {
+		order: 3;
+	}
+}
+
+@media not all and (   --mq-a   ) {
+	body {
+		order: 3;
+	}
+}

--- a/test/whitespace.expect.css
+++ b/test/whitespace.expect.css
@@ -1,0 +1,107 @@
+@media (max-width: 30em),(max-height: 30em) {
+	body {
+		order: 1;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em) {
+	body {
+		order: 1;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em) {
+	body {
+		order: 1;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em) {
+	body {
+		order: 1;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media (max-width: 30em),(max-height: 30em), (max-width: 30em), (max-height: 30em) {
+	body {
+		order: 2;
+	}
+}
+
+@media not all and (max-width: 30em),not all and (max-height: 30em) {
+	body {
+		order: 3;
+	}
+}
+
+@media not all and (max-width: 30em),not all and (max-height: 30em) {
+	body {
+		order: 3;
+	}
+}
+
+@media not all and (max-width: 30em),not all and (max-height: 30em) {
+	body {
+		order: 3;
+	}
+}
+
+@media not all and (max-width: 30em),not all and (max-height: 30em) {
+	body {
+		order: 3;
+	}
+}


### PR DESCRIPTION
This change aims to fix issue csstools/postcss-plugins#421 by adjusting the regex to factor in whitespace.

Some additional tests have been added that focus purely on confirming the whitespace handling.