### PR TITLE
fix: allow plugin to be run synchronously when not using `importFrom` or `exportTo` options

### DIFF
--- a/lib/get-custom-media-from-imports.js
+++ b/lib/get-custom-media-from-imports.js
@@ -53,6 +53,9 @@ async function getCustomMediaFromJSFile(from) {
 /* ========================================================================== */
 
 export default function getCustomMediaFromSources(sources) {
+	if (sources.length === 0) {
+		return {};
+	}
 	return sources.map(source => {
 		if (source instanceof Promise) {
 			return source;

--- a/lib/write-custom-media-to-exports.js
+++ b/lib/write-custom-media-to-exports.js
@@ -59,6 +59,9 @@ async function writeCustomMediaToMjsFile(to, customMedia) {
 /* ========================================================================== */
 
 export default function writeCustomMediaToExports(customMedia, destinations) {
+	if (destinations.length === 0) {
+		return;
+	}
 	return Promise.all(destinations.map(async destination => {
 		if (destination instanceof Function) {
 			await destination(defaultCustomMediaToJSON(customMedia));


### PR DESCRIPTION
e.g. `postcss([ postcssCustomMedia(opts) ]).process(css).sync()`